### PR TITLE
ExpressionChangedAfterItHasBeenCheckedError fix

### DIFF
--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, HostListener, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, HostListener, OnInit, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatDrawer } from '@angular/material/sidenav';
 import { AuthService } from 'src/app/services/auth.service';
@@ -23,11 +23,13 @@ export class ToolbarComponent implements OnInit, AfterViewInit {
 
   constructor(
     public authService: AuthService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private cd: ChangeDetectorRef
   ) { }
 
   ngAfterViewInit(): void {
     this.applyResponsiveNav();
+    this.cd.detectChanges();
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
hey, i saw this error in the console
` ERROR Error: NG0100: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value for '@transform': 'void'. Current value: 'open'. Find more at https://angular.io/errors/NG0100` the link in the video provides a really great explaination with a fix. just by adding ChangeDetectorRef in toolbar.components.ts

by the way, great work.